### PR TITLE
Allow multiple 'sprocketsPath' entries to be configured.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@ var Chain = require('sprockets-chain');
 
 var createSprockets = function(config) {
     var sc = new Chain();
-    sc.appendPath(config.basePath + '/' + config.sprocketsPath);
+    
+    var sprocketsPath = [].concat(config.sprocketsPath);
+    for (var i = 0, len = sprocketsPath.length; i < len; i++){
+        sc.appendPath(config.basePath + '/' + sprocketsPath[i]);
+    }
     sc.appendExtensions(".ejs");
 
     for (var i = config.sprocketsBundles.length -1; i >=0; i--) {


### PR DESCRIPTION
Hi,

My current project requires libraries to be loaded from multiple asset directories.
This change allows the `sprocketsPath` configuration property be configured as a string or an array of paths.

The current configuration is still supported:

``` javascript
    sprocketsPath: 'app/assets/javascripts'
```

Or the paths can be set as an array of strings:

``` javascript
    sprocketsPath: [
        'app/assets/javascripts',
        'bower_components'
    ]
```
