### PR TITLE
Support for absolute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var createSprockets = function(config) {
         var expanded = sc.depChain(config.sprocketsBundles[i]);
         for (var j = expanded.length -1; j >=0; j--) {
             config.files.unshift({
-                included: true, served: true, watched: false, pattern: expanded[j]
+                included: true, served: true, watched: config.autoWatch, pattern: expanded[j]
             });
         }
     }


### PR DESCRIPTION
Hi there! I am trying to use your plugin on complicated rails project. And some sprockets manifests contain assets from gems directories. So I've wrote a simple package for resolving such directories:

https://github.com/s0ber/node-gems-assets-data

But the problem is, that those directories have absolute paths, and your plugin only supports relatives ones. And this PR is fixing this problem.
