### PR TITLE
Support .jsx and .cjsx

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ var createSprockets = function(config) {
         }
     }
     sc.appendExtensions(".ejs");
+    sc.appendExtensions(".jsx");
+    sc.appendExtensions(".cjsx");
 
     for (var i = config.sprocketsBundles.length -1; i >=0; i--) {
         var expanded = sc.depChain(config.sprocketsBundles[i]);


### PR DESCRIPTION
Hi there! This pull request adds support for .jsx and .cjsx extensions for sprockets-chain. Maybe we need to make it configurable?

https://github.com/mtscout6/karma-cjsx-preprocessor